### PR TITLE
W-10705114: Update dataweave-cookbook-reference-multiple-inputs.adoc

### DIFF
--- a/modules/ROOT/pages/dataweave-cookbook-reference-multiple-inputs.adoc
+++ b/modules/ROOT/pages/dataweave-cookbook-reference-multiple-inputs.adoc
@@ -26,7 +26,7 @@ output application/xml
 books: {
   (payload filter ($.properties.year > attributes.publishedAfter) map  (item)   ->  {
     book @(year: item.properties.year): {
-      (variables.exchangeRate.USD map {
+      (exchangeRate.USD map {
         price @(currency: $.currency): $.ratio * item.price
       }),
       title: item.properties.title,


### PR DESCRIPTION
Needed to remove `variable` from before the exchangeRate.USD map to get the pricing mapping working. At least in the DataWeave Playground with a payload, attributes, and exchangeRate inputs.