### PR TITLE
Update dataweave-selectors.adoc

### DIFF
--- a/modules/ROOT/pages/dataweave-selectors.adoc
+++ b/modules/ROOT/pages/dataweave-selectors.adoc
@@ -570,7 +570,7 @@ from the input payload and output those values into a JSON array.
 %dw 2.0
 output application/json
 ---
-payload..name
+payload..*name
 ----
 
 ==== Output


### PR DESCRIPTION
Added a missing "*" for including all the different users listed in the XML object.