### PR TITLE
W-11098233: Links to the platform should not have 'www.'

### DIFF
--- a/modules/ROOT/pages/dataweave-language-introduction.adoc
+++ b/modules/ROOT/pages/dataweave-language-introduction.adoc
@@ -1270,7 +1270,7 @@ Likewise, whenever you transform from XML to JSON, make sure the resulting outpu
 * For a listing and details about all of the types you can use, see xref:dataweave-types.adoc[DataWeave Types]
 * For details on the different formats you can process with DataWeave and the parameters you can configure for each format, see xref:dataweave-formats.adoc[DataWeave Formats]
 * For details on how you can select certain components of the incoming message, see xref:dataweave-selectors.adoc[DataWeave Selectors]
-* View complete example projects that use DataWeave in the https://www.anypoint.mulesoft.com/exchange/?search=dataweave[Anypoint Exchange]
+* View complete example projects that use DataWeave in the https://anypoint.mulesoft.com/exchange/?search=dataweave[Anypoint Exchange]
 
 
 

--- a/modules/ROOT/pages/dataweave-operators.adoc
+++ b/modules/ROOT/pages/dataweave-operators.adoc
@@ -2758,7 +2758,7 @@ You can change the format of a date to fit another standard, see <<Coerce to dat
 * For a high level overview about the language, see xref:dataweave-language-introduction.adoc[DataWeave Language Introduction]
 * For a listing and details about all of the types you can use, see xref:dataweave-types.adoc[DataWeave Types]
 * For details on how to create and use your own functions, see xref:dataweave-types.adoc#functions-and-lambdas[Functions and Lambdas]
-* View complete example projects that use DataWeave in the https://www.anypoint.mulesoft.com/exchange/?search=dataweave[Anypoint Exchange]
+* View complete example projects that use DataWeave in the https://anypoint.mulesoft.com/exchange/?search=dataweave[Anypoint Exchange]
 
 == See Also
 

--- a/modules/ROOT/pages/dataweave-types.adoc
+++ b/modules/ROOT/pages/dataweave-types.adoc
@@ -971,7 +971,7 @@ When you <<DataWeave Operators Sorted by Type, provide an operator>> with proper
 
 * For a high level overview about the language, see xref:dataweave-language-introduction.adoc[DataWeave Language Introduction]
 * For a reference about all of the operators that are available for using, see xref:dataweave-operators.adoc[DataWeave Operators]
-* View complete example projects that use DataWeave in the https://www.anypoint.mulesoft.com/exchange/?search=dataweave[Anypoint Exchange]
+* View complete example projects that use DataWeave in the https://anypoint.mulesoft.com/exchange/?search=dataweave[Anypoint Exchange]
 
 
 == See Also


### PR DESCRIPTION
[W-11098233](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000wLRxMYAW/view): 
Based on the engineering feedback, we should update the links to the Anypoint platform to remove the `www.` section of the URL as it might not be fully supported.
