### PR TITLE
W-11098233: Links to the platform should not have 'www.'

### DIFF
--- a/modules/ROOT/pages/dataweave-types.adoc
+++ b/modules/ROOT/pages/dataweave-types.adoc
@@ -846,4 +846,4 @@ DataWeave function modules:
 
 * xref:dataweave-language-introduction.adoc[DataWeave Scripts]
 
-* https://www.anypoint.mulesoft.com/exchange/?search=dataweave[Anypoint Exchange (List of Projects that use DataWeave)]
+* https://anypoint.mulesoft.com/exchange/?search=dataweave[Anypoint Exchange (List of Projects that use DataWeave)]


### PR DESCRIPTION
[W-11098233](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000wLRxMYAW/view): 
Based on the engineering feedback, we should update the links to the Anypoint platform to remove the `www.` section of the URL as it might not be fully supported.