### PR TITLE
 W-11171692: Timezone: Use zzz instead of buggy OOOO and ZZZZ patterns

### DIFF
--- a/modules/ROOT/pages/dataweave-types.adoc
+++ b/modules/ROOT/pages/dataweave-types.adoc
@@ -326,7 +326,7 @@ output application/json
   { "nanosecondCountOfDay-N" : now() as String {format: "N"} },
   { "timeZoneID-VV" : now() as String {format: "VV"} },
   { "timeZoneName-zz" : now() as String {format: "zz"} },
-  { "localizedZoneOffset-OOOO" : now() as String {format: "OOOO"} },
+  { "localizedZoneOffset-zzz" : now() as String {format: "zzz"} },
   { "localizedZoneOffset-O" : now() as String {format: "O"} },
   { "timeZoneOffsetZforZero-XXX" : now() as String {format: "XXX"} },
   { "timeZoneOffsetZforZero-XX" : now() as String {format: "XX"} },
@@ -334,8 +334,7 @@ output application/json
   { "timeZoneOffset-xxx" : now() as String {format: "xxx"} },
   { "timeZoneOffset-xx" : now() as String {format: "xx"} },
   { "timeZoneOffset-x" : now() as String {format: "x"} },
-  { "timeZoneOffset-Z" : now() as String {format: "Z"} },
-  { "timeZoneOffset-ZZZZ" : now() as String {format: "ZZZZ"} }
+  { "timeZoneOffset-Z" : now() as String {format: "Z"} } }
  ]
 ----
 
@@ -392,7 +391,7 @@ Notice the use of the syntax to format the date or time.
   { "nanosecondCountOfDay-N": "51614271000000" },
   { "timeZoneID-VV": "America/Los_Angeles" },
   { "timeZoneName-zz": "PDT" },
-  { "localizedZoneOffset-OOOO": "GMT-07:00" },
+  { "localizedZoneOffset-zzz": "GMT-07:00" },
   { "localizedZoneOffset-O": "GMT-7" },
   { "timeZoneOffsetZforZero-XXX": "-07:00" },
   { "timeZoneOffsetZforZero-XX": "-0700" },
@@ -400,8 +399,7 @@ Notice the use of the syntax to format the date or time.
   { "timeZoneOffset-xxx": "-07:00" },
   { "timeZoneOffset-xx": "-0700" },
   { "timeZoneOffset-x": "-07" },
-  { "timeZoneOffset-Z": "-0700" },
-  { "timeZoneOffset-ZZZZ": "GMT-07:00" }
+  { "timeZoneOffset-Z": "-0700" }
 ]
 ----
 


### PR DESCRIPTION
Workaround for Timezone java bug: "Thu Apr 07 2022 10:05:15 GMT+02:00" as DateTime {format: "E MMM d y HH:mm:ss OOOO"} (and ZZZZ results in error String index out of range. Patterns OOOO and ZZZZ are not usable. 
Pattern zzz is not documented but it works.  See related bug description: https://stackoverflow.com/questions/37287103/why-does-gmt8-fail-to-parse-with-pattern-o-despite-being-copied-straight-ou

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [x] Run link checker to check for broken xrefs
- [x] Check for orphan files
- [x] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [x] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [x] If applicable, verify that the software actually got released
