### PR TITLE
W-11047594. Fix supported timezones documentation

### DIFF
--- a/modules/ROOT/pages/dataweave-cookbook-change-time-zone.adoc
+++ b/modules/ROOT/pages/dataweave-cookbook-change-time-zone.adoc
@@ -22,7 +22,7 @@ include::partial$cookbook-dw/change-time-zone/out.json[]
 [[timezone-ids]]
 == Time Zone IDs
 
-In addition to accepting time zone values such as `-07:00`, DataWeave accepts Java 8 `TimeZone` ID values, which are available through a Java method call to `TimeZone.getAvailableIDs()`.
+In addition to accepting time zone values such as `-07:00`, DataWeave accepts Java 8 `TimeZone` ID values, which are available through a Java method call to `ZoneId.getAvailableZoneIds()`.
 
 To see all available values in the following table, scroll right.
 
@@ -715,36 +715,6 @@ Z:
 
 * Zulu
 
-Additional Codes:
-
-* EST
-* HST
-* MST
-* ACT
-* AET
-* AGT
-* ART
-* AST
-* BET
-* BST
-* CAT
-* CNT
-* CST
-* CTT
-* EAT
-* ECT
-* IET
-* IST
-* JST
-* MIT
-* NET
-* NST
-* PLT
-* PNT
-* PRT
-* PST
-* SST
-* VST
 |===
 
 == Related Examples


### PR DESCRIPTION
Some short 3 letter timezone codes were removed from the new java api since they were ambiguous. DataWeave uses timezones in ZoneId.getAvailableZoneIds(), not TimeZone.getAvailableIDs() which is an older api.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
