### PR TITLE
[W-11689882] remove unused annotation

### DIFF
--- a/modules/ROOT/pages/dataweave-cookbook-pluck.adoc
+++ b/modules/ROOT/pages/dataweave-cookbook-pluck.adoc
@@ -66,7 +66,7 @@ payload pluck (value,key)  -> {
 </mule>
 ----
 
-<1>  Note that the Transform Message configures the following DataWeave script:
+Note that the Transform Message configures the following DataWeave script:
 
 [source,dataweave,linenums]
 ----


### PR DESCRIPTION
ref: [W-11689882](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-11689882)

remove the extra annotation, as it doesn't seem to be referencing any specific line in the code snippet that is right before it.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
