### PR TITLE
CDATA must be CData (it's case sensitive)

### DIFF
--- a/modules/ROOT/pages/dataweave-formats-xml.adoc
+++ b/modules/ROOT/pages/dataweave-formats-xml.adoc
@@ -23,7 +23,7 @@ To understand the parsing strategies that DataWeave readers and writers can appl
 [[format_xml_cdata]]
 == CData Custom Type
 
-`CData` is a custom DataWeave data type for XML that is used to identify a Character DATA (CDATA) block. The `CData` type tells the XML writer to wrap content inside a `CDATA` block or to check for an input string inside a `CDATA` block. In DataWeave, `CData` inherits from the type `String`.
+`CData` is a custom DataWeave data type for XML that is used to identify a Character DATA (CData) block. The `CData` type tells the XML writer to wrap content inside a `CData` block or to check for an input string inside a `CData` block. In DataWeave, `CData` inherits from the type `String`.
 
 [[examples]]
 == Examples
@@ -399,9 +399,9 @@ ns f https://www.w3schools.com/furniture
 ----
 
 [[example7]]
-=== Example: Create a CDATA Element
+=== Example: Create a CData Element
 
-This example shows how to use the `CData` type to create a CDATA element in the XML output.
+This example shows how to use the `CData` type to create a CData element in the XML output.
 
 ==== Source
 
@@ -419,33 +419,33 @@ output application/xml
 
 ==== Output
 
-The output encloses the input `String` value in a CDATA block, which contains the special characters, `&lt;` and `&gt;`, from the input.
+The output encloses the input `String` value in a CData block, which contains the special characters, `&lt;` and `&gt;`, from the input.
 
 [source,xml,linenums]
 ----
 <?xml version='1.0' encoding='UTF-8'?>
-<test><![CDATA[A text <a>]]></test>
+<test><![CData[A text <a>]]></test>
 ----
 
 [[example8]]
-=== Example: Check for CDATA in a `String`
+=== Example: Check for CData in a `String`
 
-This example indicates whether a given `String` value is CDATA.
+This example indicates whether a given `String` value is CData.
 
 ==== Input
 
 The XML serves as the input payload to the DataWeave source. Notice that the
-`test` element contains a CDATA block.
+`test` element contains a CData block.
 
 [source,xml,linenums]
 ----
 <?xml version='1.0' encoding='UTF-8'?>
-<test><![CDATA[A text <a>]]></test>
+<test><![CData[A text <a>]]></test>
 ----
 
 ==== Source
 
-The DataWeave script uses the `is CData` expression to determine whether the `String` value is CDATA.
+The DataWeave script uses the `is CData` expression to determine whether the `String` value is CData.
 
 [source,dataweave,linenums]
 ----
@@ -453,13 +453,13 @@ The DataWeave script uses the `is CData` expression to determine whether the `St
 output application/json
 ---
 {
-    test: payload.test is CDATA
+    test: payload.test is CData
 }
 ----
 
 ==== Output
 
-The JSON output contains the value `true`, which indicates tha the input `String` value is CDATA.
+The JSON output contains the value `true`, which indicates tha the input `String` value is CData.
 
 [source,json,linenums]
 ----


### PR DESCRIPTION
Copying the examples with `as CDATA` produces errors. It needs to be CData (case sensitive)

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
