### PR TITLE
[W-12490096] remove extra line

### DIFF
--- a/modules/ROOT/pages/dataweave-cookbook-use-regex.adoc
+++ b/modules/ROOT/pages/dataweave-cookbook-use-regex.adoc
@@ -27,7 +27,6 @@ This example uses regular expressions in a number of DataWeave functions to retu
 [source,dataweave,linenums]
 ----
 include::partial$cookbook-dw/use-regular-expressions-ex01/transform.dwl[]
-
 ----
 
 .Output JSON:


### PR DESCRIPTION
ref: [W-12490096](https://gus.lightning.force.com/a07EE00001KceXKYAZ)

remove the extra line that makes the flask icon not show up

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
