### PR TITLE
W-14106012-For sorting dateTimes descending the negative value needs to be creat…

### DIFF
--- a/modules/ROOT/pages/dw-core-functions-orderby.adoc
+++ b/modules/ROOT/pages/dw-core-functions-orderby.adoc
@@ -80,6 +80,16 @@ orderDescending: ([3,8,1] orderBy -$)
 { "orderDescending": [8,3,1] }
 ----
 
+For sorting dateTimes descending the negative value needs to be created with millis:
+[source,DataWeave,linenums]
+----
+%dw 2.0
+output application/json
+---
+payload orderBy -($ as DateTime as Number {unit: "milliseconds"})
+----
+(see https://help.mulesoft.com/s/article/Comparing-dates-using-orderBy)
+
 
 [[orderby2]]
 == orderBy<T, R&#62;&#40;array: Array<T&#62;, criteria: &#40;item: T, index: Number&#41; &#45;&#62; R&#41;: Array<T&#62;


### PR DESCRIPTION
…ed with millis

See https://help.mulesoft.com/s/article/Comparing-dates-using-orderBy

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
