### PR TITLE
W-14079773: Protobuf repeated fields mapping from/to arrays

### DIFF
--- a/modules/ROOT/pages/dataweave-formats-protobuf.adoc
+++ b/modules/ROOT/pages/dataweave-formats-protobuf.adoc
@@ -233,6 +233,108 @@ The DataWeave script outputs a `ProtoBufWritingException` specifying which `oneo
 Since DataWeave admits repeated fields, Protobuf repeated fields are matched to
 DataWeave repeated fields, and vice versa. Note that the DataWeave object being written has to match the schema being used. If the schema does not specify a field as repeated and the DataWeave script has that field more than once, the script fails.
 
+[[example_protobuf_array_to_repeated]]
+=== Example: Transform a JSON array to a Protobuf repeated field
+
+The following example shows how to generate a `proto` message with a repeated field obtained from a JSON array.
+
+==== Schema
+
+The following schema specifies the protocol used in this example.
+
+[source,protobuf,linenums]
+----
+syntax = "proto3";
+
+package examples.repeated;
+
+
+message People {
+  repeated string names = 1;
+}
+----
+
+==== Input
+
+The JSON input serves as the payload to the DataWeave source.
+
+[source,json,linenums]
+----
+{
+  "names": [
+    "Mariano",
+    "Shoki",
+    "Tomo",
+    "Ana"
+  ]
+}
+----
+
+==== Source
+
+The DataWeave script uses the `reduce` function to generate a new field for each name in the array.
+
+[source,dataweave,linenums]
+----
+%dw 2.0
+output application/x-protobuf messageType='examples.repeated.People',descriptorUrl="descriptors/examples.dsc"
+---
+reduce(payload.names, (item, acc = {}) ->  acc ++ {names: item})
+----
+
+==== Output
+
+The DataWeave script outputs a Protobuf message with the repeated field containing all the names from the JSON array.
+
+[[example_protobuf_repeated_to_array]]
+=== Example: Transform a Protobuf repeated field to a JSON array
+
+The following example shows how to transform a `proto` message with a repeated field to a JSON array.
+
+==== Schema
+
+The following schema specifies the protocol used in this example.
+
+[source,protobuf,linenums]
+----
+syntax = "proto3";
+
+package examples.repeated;
+
+
+message People {
+  repeated string names = 1;
+}
+----
+
+==== Source
+
+The DataWeave script outputs a JSON message containing an array of names.
+
+[source,dataweave,linenums]
+----
+%dw 2.0
+output application/x-protobuf messageType='examples.repeated.People',descriptorUrl="descriptors/examples.dsc"
+---
+names: payload.people.*names
+----
+
+==== Output
+
+The DataWeave script outputs a JSON message containing an array of names.
+
+[source,json,linenums]
+----
+{
+  "names": [
+    "Mariano",
+    "Shoki",
+    "Tomo",
+    "Ana"
+  ]
+}
+----
+
 === Unknowns
 
 Protobuf offers capabilities for forward and backward compatibility of protocols. In order

--- a/modules/ROOT/pages/dataweave-formats-protobuf.adoc
+++ b/modules/ROOT/pages/dataweave-formats-protobuf.adoc
@@ -234,7 +234,7 @@ Since DataWeave admits repeated fields, Protobuf repeated fields are matched to
 DataWeave repeated fields, and vice versa. Note that the DataWeave object being written has to match the schema being used. If the schema does not specify a field as repeated and the DataWeave script has that field more than once, the script fails.
 
 [[example_protobuf_array_to_repeated]]
-=== Example: Transform a JSON array to a Protobuf Repeated Field
+=== Example: Transform a JSON Array to a Protobuf Repeated Field
 
 The following example shows how to generate a `proto` message with a repeated field obtained from a JSON array.
 

--- a/modules/ROOT/pages/dataweave-formats-protobuf.adoc
+++ b/modules/ROOT/pages/dataweave-formats-protobuf.adoc
@@ -287,7 +287,7 @@ reduce(payload.names, (item, acc = {}) ->  acc ++ {names: item})
 The DataWeave script outputs a Protobuf message with the repeated field containing all the names from the JSON array.
 
 [[example_protobuf_repeated_to_array]]
-=== Example: Transform a Protobuf Repeated Field to a JSON array
+=== Example: Transform a Protobuf Repeated Field to a JSON Array
 
 The following example shows how to transform a `proto` message with a repeated field to a JSON array.
 

--- a/modules/ROOT/pages/dataweave-formats-protobuf.adoc
+++ b/modules/ROOT/pages/dataweave-formats-protobuf.adoc
@@ -234,7 +234,7 @@ Since DataWeave admits repeated fields, Protobuf repeated fields are matched to
 DataWeave repeated fields, and vice versa. Note that the DataWeave object being written has to match the schema being used. If the schema does not specify a field as repeated and the DataWeave script has that field more than once, the script fails.
 
 [[example_protobuf_array_to_repeated]]
-=== Example: Transform a JSON array to a Protobuf repeated field
+=== Example: Transform a JSON array to a Protobuf Repeated Field
 
 The following example shows how to generate a `proto` message with a repeated field obtained from a JSON array.
 

--- a/modules/ROOT/pages/dataweave-formats-protobuf.adoc
+++ b/modules/ROOT/pages/dataweave-formats-protobuf.adoc
@@ -287,7 +287,7 @@ reduce(payload.names, (item, acc = {}) ->  acc ++ {names: item})
 The DataWeave script outputs a Protobuf message with the repeated field containing all the names from the JSON array.
 
 [[example_protobuf_repeated_to_array]]
-=== Example: Transform a Protobuf repeated field to a JSON array
+=== Example: Transform a Protobuf Repeated Field to a JSON array
 
 The following example shows how to transform a `proto` message with a repeated field to a JSON array.
 

--- a/modules/ROOT/pages/dataweave-formats-protobuf.adoc
+++ b/modules/ROOT/pages/dataweave-formats-protobuf.adoc
@@ -314,7 +314,8 @@ The DataWeave script outputs a JSON message containing an array of names.
 [source,dataweave,linenums]
 ----
 %dw 2.0
-output application/x-protobuf messageType='examples.repeated.People',descriptorUrl="descriptors/examples.dsc"
+input payload application/x-protobuf messageType='examples.repeated.People',descriptorUrl="descriptors/examples.dsc"
+output application/json
 ---
 names: payload.people.*names
 ----


### PR DESCRIPTION
Added two examples showing how to map a JSON array to a Protobuf repeated field and vice versa.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
