### PR TITLE
there is no if else in dataweave,  it should be if , else and else if , the description of the code snippet is wrong 

### DIFF
--- a/modules/ROOT/pages/dataweave-flow-control.adoc
+++ b/modules/ROOT/pages/dataweave-flow-control.adoc
@@ -193,7 +193,7 @@ else { currency: "EUR" }
 }
 ----
 
-The following example is similar but takes an array as input instead of an object. The body of the script uses `if else` and `else if` statements within a `do` operation to populate the value of the `hello` variable.
+The following example is similar but takes an array as input instead of an object. The body of the script uses `if` , `else` and `else if` statements within a `do` operation to populate the value of the `hello` variable.
 
 .DataWeave Script:
 [source,dataweave,linenums]


### PR DESCRIPTION
the condition uses if, else if , else if  and then else  but the description of the code snippet was written as if else and else if , instead it should be if , else  a "," should be in between if and else

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [x] Run link checker to check for broken xrefs
- [x] Check for orphan files
- [x] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [x] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [x] If applicable, verify that the software actually got released
